### PR TITLE
style: rename methods name to be more pythonic

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -159,16 +159,16 @@
         },
         "tartiflette": {
             "hashes": [
-                "sha256:bb374568a5b8c2813c54119ca5ae95d8dd3fa15f7b3ec245a8b5d673f97def75"
+                "sha256:84b97f67b3ab3c0a5e60669379ccb7231500c9928fa44c8b2f15ceedd77d4465"
             ],
-            "version": "==0.6.7"
+            "version": "==0.6.8"
         },
         "tartiflette-aiohttp": {
             "hashes": [
-                "sha256:091b11d05d896ea6b1c685c95ddd6dd97d7f92cbadf772cee70bb1578cec6a90"
+                "sha256:a94c0a292c35a894321d9f2b51d944cd18074e4b84c9ef7ba013892bca7a7975"
             ],
             "index": "pypi",
-            "version": "==0.4.2"
+            "version": "==0.5.0"
         },
         "yarl": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -159,16 +159,16 @@
         },
         "tartiflette": {
             "hashes": [
-                "sha256:1229d7af5111fd99f78802393103e4e5ef9566f2d3b71be50711254b2a7b02ab"
+                "sha256:bb374568a5b8c2813c54119ca5ae95d8dd3fa15f7b3ec245a8b5d673f97def75"
             ],
-            "version": "==0.6.3"
+            "version": "==0.6.7"
         },
         "tartiflette-aiohttp": {
             "hashes": [
-                "sha256:778c049b8e735d03f63ce006d342dc7533864d409d52aa51f4d129e13d760197"
+                "sha256:091b11d05d896ea6b1c685c95ddd6dd97d7f92cbadf772cee70bb1578cec6a90"
             ],
             "index": "pypi",
-            "version": "==0.4.1"
+            "version": "==0.4.2"
         },
         "yarl": {
             "hashes": [

--- a/recipes_manager/data.py
+++ b/recipes_manager/data.py
@@ -1,6 +1,6 @@
 # Dictrionnary which contains the ingredients based on the
 # Recipe ID as key.
-INGREDIENTS_QUANTITY = {
+INGREDIENTS = {
     1: [
         { "name": "potato", "quantity": 10, "type": "UNIT" },
         { "name": "onion", "quantity": 2, "type": "UNIT" },

--- a/recipes_manager/mutation_resolvers.py
+++ b/recipes_manager/mutation_resolvers.py
@@ -2,24 +2,21 @@ import collections
 
 from tartiflette import Resolver
 
-from recipes_manager.data import INGREDIENTS_QUANTITY, RECIPES
+from recipes_manager.data import INGREDIENTS, RECIPES
 
 
 @Resolver("Mutation.updateRecipe")
-async def resolver_recipe(parent, args, ctx, info):
-    recipe_input = {
-        "id": 1,
-        "name": "The best Tartiflette by Eric Guelpa",
-        "cookingTime": 12
-    }
+async def update_recipe(parent, args, ctx, info):
+    if not args.get("input"):
+        raise Exception("'input' parameter is mandatory")
     
     for index, recipe in enumerate(RECIPES):
-        if recipe["id"] == recipe_input["id"]:
-            if "name" in recipe_input:
-                RECIPES[index]["name"] = recipe_input["name"]
+        if recipe["id"] == args["input"].get("id"):
+            if "name" in args["input"]:
+                RECIPES[index]["name"] = args["input"]["name"]
 
-            if "cookingTime" in recipe_input:
-                RECIPES[index]["cookingTime"] = recipe_input["cookingTime"]
+            if "cookingTime" in args["input"]:
+                RECIPES[index]["cookingTime"] = args["input"]["cookingTime"]
 
             return RECIPES[index]
 

--- a/recipes_manager/query_resolvers.py
+++ b/recipes_manager/query_resolvers.py
@@ -2,16 +2,16 @@ import collections
 
 from tartiflette import Resolver
 
-from recipes_manager.data import INGREDIENTS_QUANTITY, RECIPES
+from recipes_manager.data import INGREDIENTS, RECIPES
 
 
 @Resolver("Query.recipes")
-async def resolver_recipe(parent, args, ctx, info):
+async def resolve_recipes(parent, args, ctx, info):
     return RECIPES
 
 
 @Resolver("Query.recipe")
-async def resolver_recipe(parent, args, ctx, info):
+async def resolve_recipe(parent, args, ctx, info):
     recipe = [r for r in RECIPES if r["id"] == int(args["id"])]
 
     if not recipe:
@@ -20,9 +20,9 @@ async def resolver_recipe(parent, args, ctx, info):
     return recipe[0]
 
 
-@Resolver("Recipe.ingredientsQuantity")
-async def resolver_recipe(parent, args, ctx, info):
-    if parent and parent["id"] in INGREDIENTS_QUANTITY:
-        return INGREDIENTS_QUANTITY[parent["id"]]
+@Resolver("Recipe.ingredients")
+async def resolve_ingredients(parent, args, ctx, info):
+    if parent and parent["id"] in INGREDIENTS:
+        return INGREDIENTS[parent["id"]]
     
     return None

--- a/recipes_manager/sdl/Query.graphql
+++ b/recipes_manager/sdl/Query.graphql
@@ -9,7 +9,7 @@ enum IngredientType {
     UNIT
 }
 
-type IngredientQuantity {
+type Ingredient {
     name: String!
     quantity: Float!
     type: IngredientType!
@@ -18,6 +18,6 @@ type IngredientQuantity {
 type Recipe {
   id: Int
   name: String
-  ingredientsQuantity: [IngredientQuantity]
+  ingredients: [Ingredient]
   cookingTime: Int
 }

--- a/recipes_manager/sdl/Query.graphql
+++ b/recipes_manager/sdl/Query.graphql
@@ -4,15 +4,15 @@ type Query {
 }
 
 enum IngredientType {
-    GRAM
-    LITER
-    UNIT
+  GRAM
+  LITER
+  UNIT
 }
 
 type Ingredient {
-    name: String!
-    quantity: Float!
-    type: IngredientType!
+  name: String!
+  quantity: Float!
+  type: IngredientType!
 }
 
 type Recipe {

--- a/recipes_manager/sdl/Subscription.graphql
+++ b/recipes_manager/sdl/Subscription.graphql
@@ -3,11 +3,11 @@ type Subscription {
 }
 
 enum CookingStatus {
-  COOKING,
+  COOKING
   COOKED
 }
 
 type CookingTimer {
-  remainingTime: Int!,
+  remainingTime: Int!
   status: CookingStatus!
 }

--- a/recipes_manager/subscription_resolvers.py
+++ b/recipes_manager/subscription_resolvers.py
@@ -5,7 +5,7 @@ from tartiflette import Subscription
 from recipes_manager.data import RECIPES
 
 @Subscription("Subscription.launchAndWaitCookingTimer")
-async def subscription_cooking_time(
+async def on_cooking_time(
     parent_result, args, ctx, info
 ):
   recipe = [r for r in RECIPES if r["id"] == int(args["id"])]

--- a/recipes_manager/subscription_resolvers.py
+++ b/recipes_manager/subscription_resolvers.py
@@ -11,7 +11,7 @@ async def on_cooking_time(
   recipe = [r for r in RECIPES if r["id"] == int(args["id"])]
 
   if not recipe:
-    raise Exception(f"The recipe with the id '{args['d']}' doesn't exist.")
+    raise Exception(f"The recipe with the id '{args['id']}' doesn't exist.")
 
   for index in range(0, recipe[0]["cookingTime"]):
     yield {


### PR DESCRIPTION
As suggested by @florimondmanca in the [tartiflette repository](https://github.com/dailymotion/tartiflette/issues/169). The methods name have been renamed to be more aligned with the 'Zen of python' mindset.

- [ ] Align documentation with this project. [pull-request started by @florimondmanca](https://github.com/dailymotion/tartiflette/pull/167)  